### PR TITLE
configure concede

### DIFF
--- a/src/BoosterBot/ConquestBot.cs
+++ b/src/BoosterBot/ConquestBot.cs
@@ -10,15 +10,17 @@ namespace BoosterBot
         private readonly GameUtilities _game;
         private readonly GameState _maxTier;
         private readonly int _retreatAfterTurn;
+        private readonly bool _concedeAfterRetreat;
         private Stopwatch _matchTimer { get; set; }
 
-        public ConquestBot(double scaling, bool verbose, bool autoplay, bool saveScreens, GameState maxTier, int retreatAfterTurn)
+        public ConquestBot(double scaling, bool verbose, bool autoplay, bool saveScreens, GameState maxTier, int retreatAfterTurn, bool concedeAfterRetreat)
         {
             _logPath = $"logs\\conquest-log-{DateTime.Now.ToString("yyyyMMddHHmmss")}.txt";
             _config = new BotConfig(scaling, verbose, autoplay, saveScreens, _logPath);
             _game = new GameUtilities(_config);
             _maxTier = maxTier;
             _retreatAfterTurn = retreatAfterTurn;
+            _concedeAfterRetreat = concedeAfterRetreat;
 
             // Debug();
         }
@@ -307,9 +309,12 @@ namespace BoosterBot
                         _game.ClickRetreat();
                         Thread.Sleep(5000);
 
-						Logger.Log("Attempting concede...", _logPath);
-						_game.ClickConcede();
-						Thread.Sleep(5000);
+                        if (_concedeAfterRetreat)
+                        {
+                            Logger.Log("Attempting concede...", _logPath);
+                            _game.ClickConcede();
+                            Thread.Sleep(5000);
+                        }
 					}
 					else
                     {
@@ -406,9 +411,6 @@ namespace BoosterBot
                     Logger.Log("Identified Conquest lobby...", _logPath);
                     return true;
                 }
-
-                if (totalSleep > 60000)
-                    return true;
             }
 
             return AcceptResult();

--- a/src/BoosterBot/Program.cs
+++ b/src/BoosterBot/Program.cs
@@ -69,9 +69,16 @@ internal class Program
 
                 var retreatAfterTurn = GetRetreatAfterTurn();
 
+                var concedeAfterRetreat = true;
+
+                if (retreatAfterTurn >= 1 && retreatAfterTurn <= 7)
+                {
+                    concedeAfterRetreat = GetConcedeAfterRetreat();
+                }
+
                 PrintTitle();
 
-                IBoosterBot bot = (mode == 1) ? new ConquestBot(scaling, verbose, autoplay, saveScreens, maxTier, retreatAfterTurn) : new LadderBot(scaling, verbose, autoplay, saveScreens, retreatAfterTurn);
+                IBoosterBot bot = (mode == 1) ? new ConquestBot(scaling, verbose, autoplay, saveScreens, maxTier, retreatAfterTurn, concedeAfterRetreat) : new LadderBot(scaling, verbose, autoplay, saveScreens, retreatAfterTurn, concedeAfterRetreat);
  
                 try
                 {
@@ -245,7 +252,33 @@ internal class Program
 		return GetRetreatAfterTurn();
 	}
 
-	private static void PurgeExecutables()
+    private static bool GetConcedeAfterRetreat()
+    {
+        PrintTitle();
+
+        Console.WriteLine("Do you want to concede after retreat?\n");
+        Console.WriteLine("[1] Yes");
+        Console.WriteLine("[2] No");
+        Console.WriteLine();
+        Console.Write("Waiting for selection...");
+
+        var key = Console.ReadKey();
+
+        if (key.KeyChar == '1')
+        {
+            return true;
+        }
+        else if (key.KeyChar == '2')
+        {
+            return false;
+        }
+        else
+        {
+            return GetConcedeAfterRetreat();
+        }
+    }
+    
+    private static void PurgeExecutables()
     {
         var process = Process.GetCurrentProcess().ProcessName + ".exe";
         var files = Directory.GetFiles(Directory.GetCurrentDirectory(), "*.exe");


### PR DESCRIPTION
It looks like you get one booster per turn - win or lose.  It is faster to not concede after each round but that is more painful for the other player.  

Added the option to concede after retreating to enable a single game to have multiple rounds which will get 4 boosters per round.