### PR TITLE
Bug - Conquest Loop

### DIFF
--- a/src/BoosterBot/ConquestBot.cs
+++ b/src/BoosterBot/ConquestBot.cs
@@ -413,7 +413,7 @@ namespace BoosterBot
             }
 
             Log("Waiting for post-match screens...");
-            Thread.Sleep(10000);
+            Thread.Sleep(15000);
 
             var totalSleep = 0;
             Log("Checking for post-round screens...", true);
@@ -443,12 +443,18 @@ namespace BoosterBot
 
             _config.GetWindowPositions();
             Log("Checking for win, loss, or ticket claim screens...");
-            if (Check(_game.CanIdentifyConquestLossContinue) || Check(_game.CanIdentifyConquestWinNext) || Check(_game.CanIdentifyConquestTicketClaim))
+            if (Check(_game.CanIdentifyConquestLossContinue) || Check(_game.CanIdentifyConquestWinNext))
             {
+                Log("Clicking next...");
                 _game.ClickPlay();
                 Thread.Sleep(5000);
                 _config.GetWindowPositions();
                 return AcceptResult();
+            }
+            else if (Check(_game.CanIdentifyConquestTicketClaim))
+            {
+                Log("Claiming ticket...");
+                _game.ClickClaim();
             }
 
             return true;

--- a/src/BoosterBot/Helpers/GameUtilities.cs
+++ b/src/BoosterBot/Helpers/GameUtilities.cs
@@ -389,6 +389,11 @@ namespace BoosterBot
         public void ClickNext() => SystemUtilities.Click(_config.NextPoint);
 
         /// <summary>
+        /// Simulates clicking the "Claim" button after winning a Conquest match.
+        /// </summary>
+        public void ClickClaim() => SystemUtilities.Click(_config.ClaimPoint);
+
+        /// <summary>
         /// Simulates clicks to from a match.
         /// </summary>
         public void ClickRetreat()

--- a/src/BoosterBot/Models/BotConfig.cs
+++ b/src/BoosterBot/Models/BotConfig.cs
@@ -37,7 +37,7 @@ namespace BoosterBot
                 var rand = new Random();
                 var points = new Point[2];
                 var xBound = (int)(100 * Scaling);
-                var yBound = (int)(500 * Scaling);
+                var yBound = (int)(100 * Scaling);
                 points[0] = new Point
                 {
                     X = BaseResetPointLeft.X + rand.Next(xBound),
@@ -139,6 +139,20 @@ namespace BoosterBot
                 };
             }
         }
+        private Point BaseClaimPoint { get; set; }
+        public Point ClaimPoint
+        {
+            get
+            {
+                var rand = new Random();
+                var bound = (int)(10 * Scaling);
+                return new Point
+                {
+                    X = BaseClaimPoint.X + rand.Next(-bound, bound),
+                    Y = BaseClaimPoint.Y + rand.Next(-bound, bound)
+                };
+            }
+        }
         public Point RetreatPoint { get; set; }
         public Point RetreatConfirmPoint { get; set; }
 		public Point ConcedePoint { get; set; }
@@ -236,13 +250,13 @@ namespace BoosterBot
             BaseResetPointLeft = new Point
             {
                 X = Window.Left + Scale(100),
-                Y = Window.Bottom - Scale(200)
+                Y = Window.Bottom - Scale(100)
             };
 
             BaseResetPointRight = new Point
             {
                 X = Window.Right - Scale(100),
-                Y = Window.Bottom - Scale(200)
+                Y = Window.Bottom - Scale(100)
             };
 
             ClearErrorPoint = new Point
@@ -291,6 +305,12 @@ namespace BoosterBot
             {
                 X = Window.Left + Center + Scale(300),
                 Y = Window.Bottom - Scale(60)
+            };
+
+            BaseClaimPoint = new Point
+            {
+                X = Window.Left + Center,
+                Y = Window.Bottom - Scale(135)
             };
 
             RetreatPoint = new Point


### PR DESCRIPTION
- Adjust reset click points to avoid hitting background carousel
- Adjust click point for claiming ticket after Conquest win
- Extend wait for post-match Conquest animations before processing screens