### PR TITLE
Added kill after parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Specifies the game mode that the bot should play. Valid arguments: `c`, `conques
 
 Configures the turn at which the bot should auto-retreat, if desired. Valid arguments: any integer. Value can be ignored or set to `0` if the bot should play matches to the end. Only applicable in ranked mode and will be ignored in Conquest.
 
+`-ta`, `--terminate-after`
+
+Specifies a total runtime duration in seconds after which the bot will automatically shut itself down. The check occurs between matches so the current match will always finish. Useful for running the bot for a fixed period of time. Valid arguments: any integer. Set to `0` or omit to run indefinitely.
+
 `-ct`, `--tier`
 
 Specifies the maximum tier that the bot should play if the bot was set to play Conquest. Valid arguments: `pg` (Proving Grounds), `s` (Silver), `g` (Gold), `i` (Infinite)
@@ -86,6 +90,7 @@ Specifies the maximum tier that the bot should play if the bot was set to play C
 Usage:
 - `BoosterBot.exe --mode ranked --turns 3` - Bot will farm ladder on startup, and will auto-retreat after 3 turns.
 - `BoosterBot.exe -m c -ct s` - Bot will farm Conquest on startup, but only at Silver tier or lower.
+- `BoosterBot.exe -m ranked -ta 3600` - Bot will farm ladder and shut itself down after 1 hour.
 
 **Event UI** 
 
@@ -112,7 +117,8 @@ Alternatively, many of the command-line options shown in the previous section ca
     "enabled": false,
     "gameMode": "conquest",
     "maxConquestTier": "silver",
-    "maxRankedTurns": 3
+    "maxRankedTurns": 3,
+    "terminateAfter": 0
   }
 }
 ```

--- a/src/BoosterBot/BaseBot.cs
+++ b/src/BoosterBot/BaseBot.cs
@@ -17,6 +17,7 @@ namespace BoosterBot
         protected readonly int _retreatAfterTurn;
         protected Random _rand { get; set; }
         protected Stopwatch _matchTimer { get; set; }
+        protected Stopwatch _startTime { get; set; }
 
         public BaseBot(BotConfig config, int retreat)
         {
@@ -25,6 +26,8 @@ namespace BoosterBot
             _retreatAfterTurn = retreat;
             _game = new GameUtilities(_config);
             _rand = new Random();
+            _startTime = new Stopwatch();
+            _startTime.Start();
 
             // If the bot is running on a lower resolution, we need to adjust the confidence level to account for slight variations in image quality
             if (_config.Downscaled)
@@ -75,6 +78,18 @@ namespace BoosterBot
             var result = funcCheck();
             Log(result.Logs, true);
             return result.IsMatch;
+        }
+
+        protected void CheckForTerminate()
+        {
+            if (_config.TerminateAfter > 0 && _startTime.Elapsed.TotalSeconds >= _config.TerminateAfter)
+            {
+                Log("Log_TerminatingAfter", replace: [new("%SECONDS%", _config.TerminateAfter.ToString())]);
+                Console.WriteLine();
+                Log("Menu_PressKeyToExit");
+                Thread.Sleep(2000);
+                Environment.Exit(0);
+            }
         }
 
         protected void CheckForPause()

--- a/src/BoosterBot/ConquestBot.cs
+++ b/src/BoosterBot/ConquestBot.cs
@@ -447,6 +447,7 @@ namespace BoosterBot
                 if (totalSleep > 4000 && Check(_game.CanIdentifyAnyConquestLobby))
                 {
                     Log("Conquest_Log_Menu_DetectedLobby");
+                    CheckForTerminate();
                     return true;
                 }
 
@@ -457,6 +458,7 @@ namespace BoosterBot
                 }
             }
 
+            CheckForTerminate();
             return AcceptResult();
         }
 

--- a/src/BoosterBot/EventBot.cs
+++ b/src/BoosterBot/EventBot.cs
@@ -314,6 +314,7 @@ namespace BoosterBot
                 _config.GetWindowPositions();
             }
 
+            CheckForTerminate();
             return true;
         }
     }

--- a/src/BoosterBot/LadderBot.cs
+++ b/src/BoosterBot/LadderBot.cs
@@ -271,6 +271,7 @@ namespace BoosterBot
                 _config.GetWindowPositions();
             }
 
+            CheckForTerminate();
             return true;
         }
     }

--- a/src/BoosterBot/Models/BotConfig.cs
+++ b/src/BoosterBot/Models/BotConfig.cs
@@ -171,7 +171,9 @@ namespace BoosterBot
         public List<Point> Cards { get; set; }
         public List<Point> Locations { get; set; }
 
-        public BotConfig(IConfiguration settings, LocalizationManager localizer, double scaling, bool verbose, bool autoplay, bool saveScreens, string logPath, bool useEvent, bool downscaled)
+        public int TerminateAfter { get; set; }
+
+        public BotConfig(IConfiguration settings, LocalizationManager localizer, double scaling, bool verbose, bool autoplay, bool saveScreens, string logPath, bool useEvent, bool downscaled, int terminateAfter = 0)
         {
             _settings = settings;
             _localizer = localizer;
@@ -182,6 +184,7 @@ namespace BoosterBot
             _downscaled = downscaled;
             _logPath = logPath;
             _useEvent = useEvent;
+            TerminateAfter = terminateAfter;
         }
 
         public int Scale(int x) => (int)(Scaling * x);

--- a/src/BoosterBot/Program.cs
+++ b/src/BoosterBot/Program.cs
@@ -47,6 +47,7 @@ internal class Program
         string? gameMode = null;
         string? maxConquestTier = null;
         int? maxTurns = null;
+        int? terminateAfter = null;
 
         // Parse flags:
         if (args.Length > 0)
@@ -107,6 +108,11 @@ internal class Program
                     case "--repair":
                         repair = true;
                         break;
+                    case "-terminate":
+                    case "--terminate-after":
+                    case "-ta":
+                        terminateAfter = int.Parse(args[i + 1]);
+                        break;
                 }
 
         try
@@ -138,6 +144,7 @@ internal class Program
                     gameMode ??= _configuration["defaultRunSettings:gameMode"];
                     maxConquestTier ??= _configuration["defaultRunSettings:maxConquestTier"];
                     maxTurns ??= int.Parse(_configuration["defaultRunSettings:maxRankedTurns"] ?? "0");
+                    terminateAfter ??= int.Parse(_configuration["defaultRunSettings:terminateAfter"] ?? "0");
                 }
 
                 // Process configured values and prompt user for any that are missing
@@ -169,13 +176,15 @@ internal class Program
                         };
                 }
 
-                var retreat = maxTurns > 0 || repair ? maxTurns : GetRetreatAfterTurn();
+                var retreat = maxTurns.HasValue || repair ? maxTurns : GetRetreatAfterTurn();
+                if (retreat.HasValue && (retreat < 1 || retreat > 7))
+                    retreat = 99;
 
                 PrintTitle(args);
 
                 var type = (GameMode)mode;
                 var logPath = $"logs\\{type.ToString().ToLower()}-log-{DateTime.Now.ToString("yyyyMMddHHmmss")}.txt";
-                var config = new BotConfig(_configuration, _localizer, (double)scaling, (bool)verbose, autoplay, saveScreens, logPath, (bool)ltm, (bool)downscaled);
+                var config = new BotConfig(_configuration, _localizer, (double)scaling, (bool)verbose, autoplay, saveScreens, logPath, (bool)ltm, (bool)downscaled, terminateAfter ?? 0);
                 IBoosterBot bot = mode switch
                 {
                     1 => new ConquestBot(config, retreat ?? 0, maxTier),

--- a/src/BoosterBot/Resources/Strings.resx
+++ b/src/BoosterBot/Resources/Strings.resx
@@ -306,6 +306,9 @@
   <data name="Log_Match_Exiting" xml:space="preserve">
     <value>Exiting match...</value>
   </data>
+  <data name="Log_TerminatingAfter" xml:space="preserve">
+    <value>Terminate-after duration of %SECONDS% seconds reached. Shutting down...</value>
+  </data>
   <data name="Log_Check_PostMatchScreen" xml:space="preserve">
     <value>Checking for post-match screens...</value>
   </data>

--- a/src/BoosterBot/Resources/Strings.zh-CN.resx
+++ b/src/BoosterBot/Resources/Strings.zh-CN.resx
@@ -306,6 +306,9 @@
   <data name="Log_Match_Exiting" xml:space="preserve">
     <value>退出比赛……</value>
   </data>
+  <data name="Log_TerminatingAfter" xml:space="preserve">
+    <value>已达到 %SECONDS% 秒的终止时间。正在关闭……</value>
+  </data>
   <data name="Log_Check_PostMatchScreen" xml:space="preserve">
     <value>检查赛后界面……</value>
   </data>

--- a/src/BoosterBot/appsettings.json
+++ b/src/BoosterBot/appsettings.json
@@ -10,6 +10,7 @@
     "enabled": false,
     "gameMode": "conquest",
     "maxConquestTier": "silver",
-    "maxRankedTurns": 3
+    "maxRankedTurns": 3,
+    "terminateAfter": 0
   }
 }


### PR DESCRIPTION
Summary

Adds a --terminate-after / -ta CLI parameter that automatically shuts the bot down after a specified runtime duration (in seconds).

Motivation

Users running the bot for farming sessions wanted the ability to limit runtime to a fixed period (e.g., "run for 1 hour then stop") without manually monitoring and closing the bot.

Changes

- New CLI flag: -ta / --terminate-after <seconds> - accepts an integer representing the total seconds the bot should  run before shutting down. Defaults to 0 (run indefinitely).
- New config key: defaultRunSettings.terminateAfter in appsettings.json serves the same purpose when using config-based runs.
- Runtime tracking: A Stopwatch starts in BaseBot's constructor, and a new CheckForTerminate() method compares elapsed time  against the configured threshold.
- Termination points: CheckForTerminate() is called between matches in ConquestBot, LadderBot, and EventBot, ensuring the current match always finishes before shutdown.
- Localization: Log messages added for both English (Strings.resx) and Simplified Chinese (Strings.zh-CN.resx).
- Documentation: Updated README.md with usage examples and parameter description.

Side fix

- Improved retreat turn validation: values outside the valid range (1-7) are now clamped to 99 instead of being
 silently accepted, preventing the bot from retreating on turn 0 or on non-existent turns.
